### PR TITLE
add filter for events and archive tag

### DIFF
--- a/content/events/2024-10-12-codeweek_kickoff.md
+++ b/content/events/2024-10-12-codeweek_kickoff.md
@@ -5,7 +5,8 @@ eventdate: 2024-10-12
 location: "REACH Startup Center | Geiststr. 24-26 | 48151 Münster"
 description: "."
 link: https://muensterland.codeweek.de/programm/veranstaltung/2024-10-12-offizielle-auftaktveranstaltung-zur-code-week-muensterland
-tags: ["Code Week", "Jugendliche", ]
+tags: ["Code Week", "Jugendliche"]
+archive: true
 ---
 
 "Komm machen!" Bei der Code Week geht es ums Selbermachen, ums Loslegen, ums gemeinsam kreativ werden. Diesen Code Week Spirit und eine Vorschau auf das Code Week-Programm der folgenden zwei Wochen könnt ihr bei unserer großen Maker- und Mitmachmesse am 12. Oktober in geballter Form erleben: Programmiert Umweltmesstationen, baut Roboter, kreiert 3D-Objekte oder testet die neusten Technik Gadgets! An vielen Mitmach-Stationen im REACH Startup Center der Universität Münster gibt es etwas zu entdecken!
@@ -27,6 +28,3 @@ tags: ["Code Week", "Jugendliche", ]
 12:30 - 13:30 Uhr | Schnupperkurs Robotik
 
 13:45 - 14:45 Uhr | Bau und Programmierung einer Umweltmessstation mit der senseBox
-
-
-

--- a/content/events/2024-10-14-iCODE_MS.md
+++ b/content/events/2024-10-14-iCODE_MS.md
@@ -7,10 +7,10 @@ location: "MExLab Experiminte | Corrensstraße | 48149 Münster"
 description: "."
 link: https://icode.ms/feriencamps/
 tags: ["iCODE_MS", "Jugendliche", "Ferienprogramm"]
+archive: true
 ---
 
 Code die Welt, wie sie dir gefällt – Das ist das Motto des diesjährigen Ferienprogramms zum Thema ‚Smart City‘. Egal ob IT-Profi oder Technik-Neuling: Wenn du dich für Klima- und Umweltschutzthemen interessierst und du Lust hast Neues zu lernen, dann bist du in diesem Ferienprogramm genau richtig! Du lernst verschiedene Tools kennen (z.B. Scratch, senseBox, 3D-Druck und weitere.) und nutzt sie, um Probleme und Fragestellungen des Alltags zu lösen. Dabei verfolgen wir immer einen Bezug zur Stadt Münster und den Gedanken, diese Stadt im nachhaltigen Sinne ein kleines Stück besser zu machen.
 Komm’ mit auf eine spannende Entdeckungsreise in die Welt der Technologien einer Smart City, des Codings und der Nachhaltigkeit!
 
 Für Kinder und Jugendliche ab 10 Jahren. Das Ferienprogramm ist kostenfrei und Snacks, Getränke und Mittagessen sind inkludiert. Vorkenntnisse werden nicht benötigt
-

--- a/content/events/2024-10-22-jugendhackt.md
+++ b/content/events/2024-10-22-jugendhackt.md
@@ -6,6 +6,7 @@ location: "Digitallabor Münster | Leonardo Campus 6a | 48149 Münster"
 description: "."
 link: https://jugendhackt.org/lab/muenster/
 tags: ["Jugend hackt", "Jugendliche", "Code Week"]
+archive: true
 ---
 
 Im Game Lab bauen wir mit dem Einsatz von Microcontrollern, CircuitPython, und eigener Hardware retro Spielekonsolen zu entwerfen und zu bauen.
@@ -13,4 +14,3 @@ Im Game Lab bauen wir mit dem Einsatz von Microcontrollern, CircuitPython, und e
 Im Mittelpunkt des Workshops steht das kreative Zusammenspiel von Elektronik und Programmierung. Ihr lernt, wie ihr Microcontroller mit CircuitPython programmieren könnt, um grundlegende Spielelogik zu entwickeln, Bildschirme anzusteuern und interaktive Steuerungen zu gestalten. Die Programmierung mit CircuitPython macht es euch leichter als andere Programmierspachen eure Ideen schnell und unkompliziert in die Tat umzusetzen. Grundsätze in Python werden nicht vorausgesetzt sind aber hilfreich!
 
 Neben den Mikrocontroller verwenden wir einfache Buttons, Joysticks, LED-Matrixen und 3D-Druck, um eigene und einfache Spiele umzusetzen.
-

--- a/content/events/2024-10-24-codeweek_fashion.md
+++ b/content/events/2024-10-24-codeweek_fashion.md
@@ -6,6 +6,7 @@ location: "Digitallabor Münster | Leonardo Campus 6a | 48149 Münster"
 description: "."
 link: https://muensterland.codeweek.de/programm/veranstaltung/609263-fashion-amp-tech-gestalte-deine-eigenen-wearables
 tags: ["Code Week", "Jugendliche", "Wearables"]
+archive: true
 ---
 
 Im Game Lab bauen wir mit dem Einsatz von Microcontrollern, CircuitPython, und eigener Hardware retro Spielekonsolen zu entwerfen und zu bauen.
@@ -13,4 +14,3 @@ Im Game Lab bauen wir mit dem Einsatz von Microcontrollern, CircuitPython, und e
 Im Mittelpunkt des Workshops steht das kreative Zusammenspiel von Elektronik und Programmierung. Ihr lernt, wie ihr Microcontroller mit CircuitPython programmieren könnt, um grundlegende Spielelogik zu entwickeln, Bildschirme anzusteuern und interaktive Steuerungen zu gestalten. Die Programmierung mit CircuitPython macht es euch leichter als andere Programmierspachen eure Ideen schnell und unkompliziert in die Tat umzusetzen. Grundsätze in Python werden nicht vorausgesetzt sind aber hilfreich!
 
 Neben den Mikrocontroller verwenden wir einfache Buttons, Joysticks, LED-Matrixen und 3D-Druck, um eigene und einfache Spiele umzusetzen.
-

--- a/content/events/2025-04-01-hyc-hackathon.md
+++ b/content/events/2025-04-01-hyc-hackathon.md
@@ -1,16 +1,10 @@
 ---
-title: "Fortbildungsangebot: Hackathon für Lehrkräfte | Entwicklung von innovativen Ideen und Projekten für digitale Schule"
+title: "Hack your City Hackathon "
 date: 2025-01-01 # only the date when the event will be released on the website
 eventdate: 2025-04-24
 location: "Digitallabor Münster | Leonardo Campus 6a | 48149 Münster"
 description: "."
-link: https://pretix.opensenselab.org/hack1311124/
-tags: ["Fortbildung", "Lehrkräfte", "Schule"]
+link: https://hackyourcity.ms
+tags: ["Hackathon", "Smart City", "Schule"]
 archive: false
 ---
-
-Sie sind Lehrkraft und möchten innovative Ansätze für eine zeitgemäße MINT-Bildung an Ihrer Schule entwickeln? Dann nehmen Sie an unserem eintägigen Hackathon teil! In diesem inspirierenden Format werden gemeinsam mit weiteren Lehrkräften aus verschiedenen Fachrichtungen kreative Ideen für eine zukunftsfähige MINT-Bildung erarbeitet.
-
-Dieser Hackathon richtet sich vorwiegend an Lehrkräfte aller weiterführenden Schulen in Münster und dem Münsterland, unabhängig vom unterrichteten Fach. Die Veranstaltung bietet Ihnen die Möglichkeit, das Format eines Hackathons als Methode für Projekttage oder Projektwochen an Ihrer Schule kennenzulernen. Gleichzeitig werden Sie durch die strukturierte Arbeitsweise in einem Hackathon in die Lage versetzt, innovative und praxistaugliche Ansätze für die MINT-Bildung zu entwickeln.
-
-Begleitet wird die Veranstaltung von Expert\*innen des openSenseLab gGmbH und weiteren erfahrenen Mentor\*innen, die Ihnen mit methodischer und fachlicher Expertise zur Seite stehen. Vorkenntnisse sind keine Erforderlich.

--- a/content/events/2025-04-01-hyc-hackathon.md
+++ b/content/events/2025-04-01-hyc-hackathon.md
@@ -1,12 +1,12 @@
 ---
 title: "Fortbildungsangebot: Hackathon für Lehrkräfte | Entwicklung von innovativen Ideen und Projekten für digitale Schule"
-date: 2024-09-30 # only the date when the event will be released on the website
-eventdate: 2024-11-13
+date: 2025-01-01 # only the date when the event will be released on the website
+eventdate: 2025-04-24
 location: "Digitallabor Münster | Leonardo Campus 6a | 48149 Münster"
 description: "."
 link: https://pretix.opensenselab.org/hack1311124/
 tags: ["Fortbildung", "Lehrkräfte", "Schule"]
-archive: true
+archive: false
 ---
 
 Sie sind Lehrkraft und möchten innovative Ansätze für eine zeitgemäße MINT-Bildung an Ihrer Schule entwickeln? Dann nehmen Sie an unserem eintägigen Hackathon teil! In diesem inspirierenden Format werden gemeinsam mit weiteren Lehrkräften aus verschiedenen Fachrichtungen kreative Ideen für eine zukunftsfähige MINT-Bildung erarbeitet.

--- a/layouts/_default/events.html
+++ b/layouts/_default/events.html
@@ -21,34 +21,35 @@
 <main>
   <section class='container l__projects js-shuffle'>
     <div class="row">
-      <h1 class="col col-12 col-sm-10 mb-2">{{ if .Params.blurb }}{{ .Params.blurb }}{{ else }}{{ .Title }}{{ end }}</h1>
+      <h1 class="col col-12 col-sm-10 mb-2">
+        {{ if .Params.blurb }}{{ .Params.blurb }}{{ else }}{{ .Title }}{{ end }}
+      </h1>
       <div class="events p-4" style="width: 100%;">
         <ul>
           {{ $allEvents := slice }}
+          {{ $now := .Date.Format "2006-01-02" }} <!-- Get the current date in the same format as eventdate -->
+
           {{ range .Pages }}
-            {{ $sortDate := (or .Params.eventDateStart .Params.eventdate .Date) }}
-            {{ $event := dict "page" . "sortDate" $sortDate }}
-            {{ $allEvents = $allEvents | append $event }}
+            {{ $eventDate := .Params.eventdate }} <!-- Get the event date -->
+            {{ $isArchived := or (.Params.archive | default false) false }}
+
+            {{ if and $eventDate (ge $eventDate $now) (not $isArchived) }} <!-- Compare eventdate with current date -->
+              {{ $event := dict "page" . "eventDate" $eventDate }}
+              {{ $allEvents = $allEvents | append $event }}
+            {{ end }}
           {{ end }}
 
-          {{ range sort $allEvents "sortDate" "asc" }}
+          {{ range sort $allEvents "eventDate" "asc" }}
             {{ $event := .page }}
             <li>
               <div class="card p-2 mb-4" style="border: 1px solid #ddd; border-radius: 15px; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);">
                 <div class="card-body p-2">
                   <h3 class="card-title mb-2"><a href="{{ $event.Permalink }}">{{ $event.Title }}</a></h3>
-                  
+
                   <div class="d-flex justify-content-start align-items-center py-2">
-                    {{ if $event.Params.eventDateStart }}
-                      <h4 class="card-subtitle text-muted pr-2">
-                        {{ $event.Params.eventDateStart | time.Format ":date_long" }}
-                        {{ with $event.Params.eventDateEnd }} - {{ . | time.Format ":date_long" }}{{ end }}
-                      </h4>
-                    {{ else if $event.Params.eventdate }}
-                      <h4 class="card-subtitle text-muted pr-2">{{ $event.Params.eventdate | time.Format ":date_long" }}</h4>
-                    {{ else }}
-                      <h4 class="card-subtitle text-muted pr-2">{{ $event.Date | time.Format ":date_long" }}</h4>
-                    {{ end }}
+                    <h4 class="card-subtitle text-muted pr-2">
+                      {{ $event.Params.eventdate | time.Format ":date_long" }}
+                    </h4>
                     
                     <div>
                       {{ range $event.Params.tags }}


### PR DESCRIPTION
This pull request includes several updates to event files and the layout for displaying events. The key changes involve adding an "archive" field to events and updating the layout to filter out archived events.

Updates to event files:

* Added `archive: true` to multiple event files to mark them as archived, including `content/events/2024-10-12-codeweek_kickoff.md`, `content/events/2024-10-14-iCODE_MS.md`, `content/events/2024-10-22-jugendhackt.md`, `content/events/2024-10-24-codeweek_fashion.md`, and `content/events/2024-11-13-hackathon.md`. [[1]](diffhunk://#diff-bd19e1ff1434dd30565f131ae0038bfb3e431f97d0deef419aeb22ee63145154L8-R9) [[2]](diffhunk://#diff-5bdf653489ff47006fa03614c60e932a7f2e750248abc2f7a7129415432f5285R10-L16) [[3]](diffhunk://#diff-5a5c030522a17d6e922c4248f9463ffdf98dadc2ebf169d1c273b342eb6874f3R9-L16) [[4]](diffhunk://#diff-e4c38958d8e8afee5b9f629cdc4a7c5ec9b33379706b0130d31a77134a093214R9-L16) [[5]](diffhunk://#diff-2eb6f0dfdd2e5aaf9b697a198a5c657d2f21bb4175f543fe6f5a6dda31567ca9R9-L16)

* Added a new event file `content/events/2025-04-01-hyc-hackathon.md` with details about a hackathon for teachers.

Updates to layout:

* Modified `layouts/_default/events.html` to include logic for filtering out archived events and sorting events by date.